### PR TITLE
Remove BugReports field from DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,6 @@ Authors@R: c(
   )
 License: GPL-2
 URL: https://github.com/hadley/proto
-BugReports: https://github.com/hadley/proto/issues
 Suggests: testthat,
     covr
 RoxygenNote: 5.0.1.9000


### PR DESCRIPTION
Not a big deal but a project shouldn't have a BugReports pointing to a non-existent issue tracker.